### PR TITLE
Corrects breakers

### DIFF
--- a/init.js
+++ b/init.js
@@ -29,12 +29,25 @@
             var _this = this;
             $.get(_this.controller + '?action=init', function(data) {
                 var response = jQuery.parseJSON(data);
+                var buffer = [];
                 jQuery.each(response, function(i, val) {
                   if(val['t'] == 'context-menu') {
-                    $('#'+val['t']).append('<hr class="'+val['a']+'">');
-                    return false;
+                    buffer.push(val['a']);
                   }
                 });
+                if (buffer.indexOf('both')) {
+                  $('#context-menu').append('<hr class="both">');
+                } else {
+                  if (buffer.indexOf('root-only') !== -1) {
+                    $('#context-menu').append('<hr class="root-only">');
+                  }
+                  if (buffer.indexOf('directory-only') !== -1) {
+                    $('#context-menu').append('<hr class="directory-only">');
+                  }
+                  if (buffer.indexOf('file-only') !== -1) {
+                    $('#context-menu').append('<hr class="file-only">');
+                  }
+                }
                 jQuery.each(response, function(i, val) {
                   if(val['t'] == 'context-menu') {
                     var macro = '<a class="'+val['a']+'" onclick="codiad.macro.execute(\''+i+'\','+val['d']+', $(\'#context-menu\').attr(\'data-path\'));"><span class="icon-'+val['i']+'"></span>'+val['n']+'</a>';


### PR DESCRIPTION
The current solution only works if every command for the context-menu has the same applying. But if the first command applies only for files and the second for just the root, there is no breaker by root. 
![root 1](https://f.cloud.github.com/assets/4389878/1231129/312a2d68-2834-11e3-8061-e4dcfaa13dbb.jpg)

This PR should correct this.
![root 2](https://f.cloud.github.com/assets/4389878/1231139/7d499062-2834-11e3-8cd1-4d4ff9630172.jpg)
